### PR TITLE
Add Kafka consumer service

### DIFF
--- a/anomaly-notification-processor/Dockerfile
+++ b/anomaly-notification-processor/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY consumer.py .
+CMD ["python", "consumer.py"]

--- a/anomaly-notification-processor/consumer.py
+++ b/anomaly-notification-processor/consumer.py
@@ -1,0 +1,24 @@
+import os
+from kafka import KafkaConsumer
+
+
+def main():
+    bootstrap_servers = os.getenv("BOOTSTRAP_SERVERS", "localhost:9092")
+    topic = os.getenv("TOPIC", "postgres.public.hfj_res_ver")
+    consumer = KafkaConsumer(
+        topic,
+        bootstrap_servers=bootstrap_servers.split(","),
+        auto_offset_reset="earliest",
+        enable_auto_commit=True,
+        group_id="anomaly-notification-consumer",
+    )
+    print(f"Consuming topic '{topic}' from {bootstrap_servers}")
+    for msg in consumer:
+        value = msg.value
+        if isinstance(value, bytes):
+            value = value.decode("utf-8", "ignore")
+        print(f"{msg.topic}:{msg.partition}:{msg.offset}: {value}")
+
+
+if __name__ == "__main__":
+    main()

--- a/anomaly-notification-processor/requirements.txt
+++ b/anomaly-notification-processor/requirements.txt
@@ -1,0 +1,1 @@
+kafka-python


### PR DESCRIPTION
## Summary
- add anomaly-notification-processor folder
- include Kafka consumer Python script and dependencies
- supply Dockerfile for the consumer service

## Testing
- `python -m py_compile anomaly-notification-processor/consumer.py`


------
https://chatgpt.com/codex/tasks/task_e_68549ca95ac083338cc8ecaae773b5d7